### PR TITLE
Test minimum versions of dependencies

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -1,0 +1,14 @@
+name: Check Markdown links
+
+on:
+  push:
+  schedule:
+    - # Run every day at 5:00 UTC
+    - cron: "0 5 * * *"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Install dependencies
         run: |
           # Hardcode the minimum version of the dependencies.
+          # E.g. '"astropy>=4.0"' to '"astropy==4.0"'
           sed -i "s/>=/==/g" pyproject.toml
+          # E.g. 'requires-python = "==3.8"' to 'requires-python = "==3.8.*"'
+          sed -E -i "s/(requires-python\s*=\s*\"[>=0-9.]*)\"/\1.*\"/g" pyproject.toml
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run Pytest

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -1,0 +1,39 @@
+name: Minimum Dependencies
+# Installs the minimum versions of the dependencies and runs the tests.
+# This test will lower the chance that users botch their installation by
+# only upgrading this project but not the dependencies.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  schedule:
+    - # Run every day at 5:00 UTC
+    - cron: "0 5 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          # Keep python-version on the lowest supported version.
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          # Hardcode the minimum version of the dependencies.
+          sed -i s/<=/==/g pyproject.toml
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Run Pytest
+        run: pytest

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -36,9 +36,10 @@ jobs:
         run: |
           # Hardcode the minimum version of the dependencies.
           # E.g. '"astropy>=4.0"' to '"astropy==4.0"'
-          sed -i "s/>=/==/g" pyproject.toml
+          # .bak is necessary for MacOS compatibility.
+          sed -i.bak "s/>=/==/g" pyproject.toml
           # E.g. 'requires-python = "==3.8"' to 'requires-python = "==3.8.*"'
-          sed -E -i "s/(requires-python\s*=\s*\"[>=0-9.]*)\"/\1.*\"/g" pyproject.toml
+          sed -E -i.bak "s/(requires-python\s*=\s*\"[>=0-9.]*)\"/\1.*\"/g" pyproject.toml
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run Pytest

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -39,9 +39,9 @@ jobs:
           # .bak is necessary for MacOS compatibility.
           sed -i.bak "s/>=/==/g" pyproject.toml
           # E.g. 'requires-python = "==3.8"' to 'requires-python = "==3.8.*"'
-          # It is difficult to use [ in the regular expression as this is seen
-          # by Powershell as indexing an array.
-          sed -E -i.bak "s/(requires-python\s*=\s*\"=+.*)\"/\1.*\"/g" pyproject.toml
+          # Single quotes must be used to prevent Powershell from
+          # interpreting the string.
+          sed -E -i.bak 's/(requires-python\s*=\s*\"=+.*)\"/\1.*\"/g' pyproject.toml
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run Pytest

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -41,7 +41,7 @@ jobs:
           # E.g. 'requires-python = "==3.8"' to 'requires-python = "==3.8.*"'
           # Single quotes must be used to prevent Powershell from
           # interpreting the string.
-          sed -E -i.bak 's/(requires-python\s*=\s*\"=+.*)\"/\1.*\"/g' pyproject.toml
+          sed -E -i.bak 's/(requires-python\s*=\s*"=+.*)"/\1.*"/g' pyproject.toml
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run Pytest

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          # Keep python-version on the lowest supported version.
+          # Keep python-version on the lowest version from pyproject.toml.
+          # Also update the regexp below.
           python-version: 3.8
       - name: Install dependencies
         run: |
@@ -39,10 +40,9 @@ jobs:
           # E.g. '"astropy>=4.0"' to '"astropy==4.0"'
           # .bak is necessary for MacOS compatibility.
           sed -i.bak "s/>=/==/g" pyproject.toml
-          # E.g. 'requires-python = "==3.8"' to 'requires-python = "==3.8.*"'
-          # Single quotes must be used to prevent Powershell from
-          # interpreting the string.
-          sed -E -i.bak 's/(requires-python\s*=\s*"=+.*)"/\1.*"/g' pyproject.toml
+          # It is difficult to make a regexp that generalizes the Python
+          # version and also works Linux, Windows, and MacOS.
+          sed -i.bak 's/requires-python = "==3.8"/requires-python = "==3.8.*"/g' pyproject.toml
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run Pytest

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -20,7 +20,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Hardcode the minimum version of the dependencies.
-          sed -i s/<=/==/g pyproject.toml
+          sed -i "s/<=/==/g" pyproject.toml
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run Pytest

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Hardcode the minimum version of the dependencies.
-          sed -i "s/<=/==/g" pyproject.toml
+          sed -i "s/>=/==/g" pyproject.toml
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run Pytest

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -22,6 +22,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -39,7 +39,7 @@ jobs:
           # .bak is necessary for MacOS compatibility.
           sed -i.bak "s/>=/==/g" pyproject.toml
           # E.g. 'requires-python = "==3.8"' to 'requires-python = "==3.8.*"'
-          sed -E -i.bak "s/(requires-python\s*=\s*\"[>=0-9.]*)\"/\1.*\"/g" pyproject.toml
+          sed -E -i.bak "s/(requires-python\s*=\s*\"[\>=0-9.]*)\"/\1.*\"/g" pyproject.toml
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run Pytest

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -39,7 +39,9 @@ jobs:
           # .bak is necessary for MacOS compatibility.
           sed -i.bak "s/>=/==/g" pyproject.toml
           # E.g. 'requires-python = "==3.8"' to 'requires-python = "==3.8.*"'
-          sed -E -i.bak "s/(requires-python\s*=\s*\"[\>=0-9.]*)\"/\1.*\"/g" pyproject.toml
+          # It is difficult to use [ in the regular expression as this is seen
+          # by Powershell as indexing an array.
+          sed -E -i.bak "s/(requires-python\s*=\s*\"=+.*)\"/\1.*\"/g" pyproject.toml
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run Pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:

--- a/docs/joss_paper/full_text.md
+++ b/docs/joss_paper/full_text.md
@@ -130,5 +130,5 @@ This development of this project was funded by the project IS538004 of the Hochs
       year = {2020},
  publisher = {​GitHub},
    journal = {​GitHub repository},
-       url = {​https://github.com/astronomyk/scopesim}
+       url = {​https://github.com/astronomyk/scopesim }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ version = "0.2.4-alpha"
 description = "Generate off-axis SCAO PSFs for the ELT"
 readme = "README.md"
 requires-python = ">=3.8"
+# When updating the version, also update the versions in .github/workflows/*
 license = {text = "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"}
 authors = [
     {name = "Eric Gendron"},
@@ -24,9 +25,11 @@ classifiers=[
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
-    "numpy>=1.17.0",
+    # Try to keep the dependencies on lower versions that have a wheel
+    # package on PyPI, for minimumdependencies.yml
+    "numpy>=1.18.0",
     "astropy>=4.0",
-    "matplotlib>=3.0.0",
+    "matplotlib>=3.2.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ classifiers=[
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
-    "numpy>=1.17",
-    "astropy",
-    "matplotlib",
+    "numpy>=1.17.0",
+    "astropy>=4.0",
+    "matplotlib>=3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -34,7 +34,7 @@ dev = [
     "scipy",
 ]
 test = [
-    "pytest",
+    "pytest>=5.0.0",
     "pytest-cov",
 ]
 docs = [


### PR DESCRIPTION
Changes:
- Add minimum versions to all dependencies; essentially the minimum that work with Python 3.8
- Add action that installs these minimal versions and runs the tests
- Runs tests on ubuntu, windows, and macos
- Add markdown_link_checker
- 'fix' one markdown link