### PR TITLE
Remove broken badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Tests](https://github.com/AstarVienna/AnisoCADO/actions/workflows/tests.yml/badge.svg)](https://github.com/AstarVienna/AnisoCADO/actions/workflows/tests.yml)
 [![Documentation Status](https://readthedocs.org/projects/anisocado/badge/?version=latest)](https://anisocado.readthedocs.io/en/latest/?badge=latest)
 
-[![Build Status](http://github-actions.40ants.com/AstarVienna/AnisoCADO/matrix.svg)](https://github.com/AstarVienna/AnisoCADO)
-
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 


### PR DESCRIPTION
This hadn't been working anyway and now trips the nightly link checker.